### PR TITLE
docs: fix test in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ describe('frame tests', () => {
   });
 
   it('should work on shadow DOM iframes', async () => {
-    await driver.get(`${addr}/shadow-iframes.html`);
+    await driver.get(`${addr}/shadow-frames.html`);
     const { violations } = await new AxeBuilder(driver)
       .options({ runOnly: 'label' })
       .analyze();


### PR DESCRIPTION
I've lost several hours over coming across this two times. 404 pages usually do not have `label` violations.