### PR TITLE
feat(crasher): have it fail axe.ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ describe('for versions without axe.runPartial', () => {
 
   it('reports frame-tested', async () => {
     await driver.get(`${addr}/crash-parent.html`);
-    const results = await new AxeBuilder(driver, axeSource + axeCrasherSource)
+    const results = await new AxeBuilder(driver, legacyAxeSource + axeCrasherSource)
       .options({ runOnly: ['label', 'frame-tested'] })
       .analyze();
 
@@ -210,9 +210,9 @@ describe('with a custom ruleset', () => {
 
   it('works without runPartial', async () => {
     const axePath = require.resolve('./fixtures/axe-core@legacy.js');
-    const axe403Source = fs.readFileSync(axePath, 'utf8');
+    const legacyAxeSource = fs.readFileSync(axePath, 'utf8');
     await page.goto(`${addr}/external/nested-iframes.html`);
-    const { violations } = await new AxePuppeteer(page, axe403Source)
+    const { violations } = await new AxePuppeteer(page, legacyAxeSource)
       .configure(dylangConfig)
       .analyze();
 

--- a/fixtures/axe-crasher.js
+++ b/fixtures/axe-crasher.js
@@ -3,16 +3,14 @@ if (document.documentElement.classList.contains('crash')) {
     throw new Error('Crashing axe.run(). Boom!');
   };
 
-  if (axe.utils.respondable) {
-    axe.utils.respondable.subscribe('axe.ping', () => {
-      // Makes axe-core unresponsive to other frames
-      // Timeouts will do the rest
-    });
-  }
-
   if (window.axe.runPartial) {
     window.axe.runPartial = function () {
       throw new Error('Crashing axe.runPartial(). Boom!');
     };
+  } else if (axe.utils.respondable) {
+    axe.utils.respondable.subscribe('axe.ping', () => {
+      // Makes axe-core unresponsive to other frames
+      // Timeouts will do the rest
+    });
   }
 }

--- a/fixtures/axe-crasher.js
+++ b/fixtures/axe-crasher.js
@@ -2,6 +2,14 @@ if (document.documentElement.classList.contains('crash')) {
   window.axe.run = function () {
     throw new Error('Crashing axe.run(). Boom!');
   };
+
+  if (axe.utils.respondable) {
+    axe.utils.respondable.subscribe('axe.ping', () => {
+      // Makes axe-core unresponsive to other frames
+      // Timeouts will do the rest
+    });
+  }
+
   if (window.axe.runPartial) {
     window.axe.runPartial = function () {
       throw new Error('Crashing axe.runPartial(). Boom!');


### PR DESCRIPTION
This should ensure that if crasher is installed in an iframe, axe-core will not be able to communicate with that frame using respondable.

This allows https://github.com/dequelabs/axe-core-npm/pull/336 to pass.