### PR TITLE
allow 4.2.0 to crash frame-tested

### DIFF
--- a/fixtures/axe-crasher.js
+++ b/fixtures/axe-crasher.js
@@ -7,6 +7,14 @@ if (document.documentElement.classList.contains('crash')) {
     window.axe.runPartial = function () {
       throw new Error('Crashing axe.runPartial(). Boom!');
     };
+  } else if (axe.frameMessenger) {
+    // Makes axe-core unresponsive to other frames
+    // Timeouts will do the rest
+    axe.frameMessenger({
+      open: function() {},
+      post: function() {},
+      close: function() {}
+    });
   } else if (axe.utils.respondable) {
     axe.utils.respondable.subscribe('axe.ping', () => {
       // Makes axe-core unresponsive to other frames


### PR DESCRIPTION
axe 4.2.0 added an assertion to `axe.respondable.subscribe` that would throw if anything tried to subscribe to the same topic. This would cause the crasher script to not crash the iframe and so our test to ensure frame-tested worked didn't pass (as the iframe still responded to `axe.run`). This uses the 4.2.0 `frameMessenger` api to remove the `axe.ping` listener and replaces it with noops, causing the iframe to not respond to `axe.ping`.