### PR TITLE
fix: reduce number of nodes created in axe-large-partial.js

### DIFF
--- a/fixtures/axe-large-partial.js
+++ b/fixtures/axe-large-partial.js
@@ -27,7 +27,7 @@ const ruleResult = {
   result: 'inapplicable',
   nodes: []
 };
-for (let i = 0; i < 500_000; i++) {
+for (let i = 0; i < 250_000; i++) {
   ruleResult.nodes.push(getNode());
 };
 


### PR DESCRIPTION
500,000 nodes was causing playwright and webdriverio tests to take too long (needed more than 800,000 ms timeout)