### PR TITLE
feat: add typings file for new index file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export const fixturesPath: string;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "axe-test-fixtures",
   "version": "1.0.0",
   "main": "index.js",
+  "typings": "index.d.ts",
   "description": "Fixtures for testing integrations of axe-core",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Prevents "no typings" errors when using the new import capability added in #25

Verified by updating `/node_modules/axe-test-fixtures` in the `axe-devtools-npm` repo with that PR checked out to include this patch, removing the `@ts-ignore` in question, and validating that it typechecked.
