### PR TITLE
chore: Update context-include-exclude.html

### DIFF
--- a/fixtures/context-include-exclude.html
+++ b/fixtures/context-include-exclude.html
@@ -5,10 +5,12 @@
   </head>
   <body>
     <h1>Context Test</h1>
-    <div class="include">include me</div>
-    <div class="exclude">exclude me</div>
-    <div class="include2">include me two</div>
-    <div class="exclude2">exclude me two</div>
+    <div class="include">include me
+      <div class="exclude">exclude me</div>
+    </div>
+    <div class="include2">include me two
+      <div class="exclude2">exclude me two</div>
+    </div>
 
     <iframe
       src="iframes/foo.html"


### PR DESCRIPTION
The way we are testing [using both `include` and `exclude`](https://github.com/dequelabs/axe-test-fixtures/blob/v1/README.md?plain=1#L345-L358) does not actually test that they both work in conjunction with the current way this file structures the DOM. `include` is an inclusive only list which means that once the test includes both `.include` elements the `.exclude` elements automatically won't be tested. So  excluding them doesn't actually do anything since they are already not part of the included DOM subtree.

If instead the `.exclude` elements were children of the `.include` elements, then including the `.include` elements would still include the `.exclude` elements. That makes it so excluding them will remove them from the passes results and make the test validate that both include and exclude can be used at the same time.