### PR TITLE
fix(watcher): add touchscreen support to dnd html.

### DIFF
--- a/fixtures/watcher/dnd.html
+++ b/fixtures/watcher/dnd.html
@@ -27,6 +27,10 @@
         opacity: 0.5;
       }
 
+      .small-box.touchstart.touchmove.touchend {
+        background-color: lightblue;
+      }
+
       .large-box {
         width: 300px;
         height: 300px;
@@ -73,6 +77,7 @@
 
       largeBox.addEventListener('dragover', event => {
         event.preventDefault()
+        largeBox.classList.add('inside')
       })
 
       largeBox.addEventListener('drop', event => {
@@ -80,10 +85,36 @@
         const data = event.dataTransfer.getData('text/plain')
         if (data === 'small-box') {
           largeBox.textContent = 'Success!'
+          smallBox.classList.remove('dragging')
+          largeBox.classList.add('inside')
         }
-        smallBox.classList.remove('dragging')
-        largeBox.classList.add('inside')
       })
+
+      largeBox.addEventListener('drop', event => {
+        event.preventDefault()
+        const data = event.dataTransfer.getData('text/plain')
+        if (data === 'small-box') {
+          largeBox.textContent = 'Success!'
+          smallBox.classList.remove('dragging')
+          largeBox.classList.add('inside')
+        }
+      })
+
+      // Touch events
+      smallBox.addEventListener('touchstart', event => {
+        event.preventDefault()
+        smallBox.classList.add('touchstart')
+      }, { passive: false });
+
+      smallBox.addEventListener('touchmove', event => {
+        event.preventDefault()
+        smallBox.classList.add('touchmove')
+      }, { passive: false });
+
+      smallBox.addEventListener('touchend', event => {
+        event.preventDefault()
+        smallBox.classList.add('touchend')
+      }, { passive: false });
     </script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds touchscreen handling to the dnd.html file, so it can be used by the puppeteer tests in `jazzband/integrations/javascript`. It also modifies some of the existing dnd functionality.