### PR TITLE
fix: ensure element exists before appending child within remount fixture

### DIFF
--- a/fixtures/watcher/remount.html
+++ b/fixtures/watcher/remount.html
@@ -1,75 +1,95 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Continuous Button Remounting</title>
     <script>
-      const urlParams = new URLSearchParams(window.location.search)
+      const urlParams = new URLSearchParams(window.location.search);
       const unmountDuringAxe =
-        !!urlParams.get('unmountDuringAxe') &&
-        urlParams.get('unmountDuringAxe') !== 'false'
+        !!urlParams.get("unmountDuringAxe") &&
+        urlParams.get("unmountDuringAxe") !== "false";
       const remountIntervalMs =
-        parseInt(urlParams.get('remountInterval'), 10) || 0
-      const axeRunDelayMs = parseInt(urlParams.get('axeRunDelay'), 10) || 0
+        parseInt(urlParams.get("remountInterval"), 10) || 0;
+      const axeRunDelayMs = parseInt(urlParams.get("axeRunDelay"), 10) || 0;
 
       function onAxeInProgress() {
         if (unmountDuringAxe) {
-          unmountButton('permanent')
+          unmountButton("permanent");
         }
         if (axeRunDelayMs) {
-          const start = Date.now()
+          const start = Date.now();
           while (Date.now() - start < axeRunDelayMs) {}
         }
       }
 
-      function unmountButton(duration = 'temporary') {
-        const oldButton = document.getElementById('target')
+      function unmountButton(duration = "temporary") {
+        const oldButton = document.getElementById("target");
         if (oldButton) {
-          oldButton.parentNode.removeChild(oldButton)
+          oldButton.parentNode.removeChild(oldButton);
         }
-        if (duration === 'permanent') {
-          clearInterval(remountTimer)
+        if (duration === "permanent") {
+          clearInterval(remountTimer);
         }
       }
 
-      let remountTimer
+      let remountTimer;
       function remountButton() {
-        unmountButton('temporary')
-        const button = document.createElement('button')
-        button.setAttribute('id', 'target')
-        button.innerHTML = `Target Button (continuously remounted every ${remountIntervalMs}ms)`
-        document.getElementById('target-container').appendChild(button)
-      }
+        unmountButton("temporary");
 
-      remountTimer = setInterval(remountButton, remountIntervalMs)
-      window.addEventListener('DOMContentLoaded', remountButton)
+        const targetContainer = document.getElementById("target-container");
+        // We should only attempt to remount the button if the target container is
+        // present in the DOM. Otherwise, we get errors when attempting to append children elements
+        if (!targetContainer) {
+          console.error("Target container not found");
+          return;
+        }
+
+        const button = document.createElement("button");
+        button.setAttribute("id", "target");
+        button.innerHTML = `Target Button (continuously remounted every ${remountIntervalMs}ms)`;
+        targetContainer.appendChild(button);
+      }
 
       function remountScrollableParent() {
-        const oldParent = document.getElementById('remount-parent')
+        const oldParent = document.getElementById("remount-parent");
         if (oldParent) {
-          oldParent.parentNode.removeChild(oldParent)
+          oldParent.parentNode.removeChild(oldParent);
         }
 
-        const parent = document.createElement('div')
-        parent.setAttribute('id', 'remount-parent')
-        parent.setAttribute('style', 'height: 100px; overflow: hidden;')
-        const button = document.createElement('button')
-        button.setAttribute('id', 'remount-target')
-        button.setAttribute('style', 'margin-top: 900px; height: 100px;')
-        button.innerHTML = `Scrollable Target Button (continously remounted every ${remountIntervalMs}ms)`
-        parent.appendChild(button)
-        document.getElementById('remount-container').appendChild(parent)
+        const parent = document.createElement("div");
+        parent.setAttribute("id", "remount-parent");
+        parent.setAttribute("style", "height: 100px; overflow: hidden;");
+        const button = document.createElement("button");
+        button.setAttribute("id", "remount-target");
+        button.setAttribute("style", "margin-top: 900px; height: 100px;");
+        button.innerHTML = `Scrollable Target Button (continously remounted every ${remountIntervalMs}ms)`;
+        parent.appendChild(button);
+
+        const remountContainer = document.getElementById("remount-container");
+        // We should only attempt to remount the button if the target container is
+        // present in the DOM. Otherwise, we get errors when attempting to append children elements
+        if (!remountContainer) {
+          console.error("Remount container not found");
+          return;
+        }
+
+        remountContainer.appendChild(parent);
       }
 
-      setInterval(remountScrollableParent, remountIntervalMs)
-      window.addEventListener('DOMContentLoaded', remountScrollableParent)
+      window.addEventListener("DOMContentLoaded", () => {
+        remountButton();
+        remountScrollableParent();
 
-      window.addEventListener('message', event => {
+        remountTimer = setInterval(remountButton, remountIntervalMs);
+        setInterval(remountScrollableParent, remountIntervalMs);
+      });
+
+      window.addEventListener("message", (event) => {
         try {
           if (JSON.parse(event.data).payload.axe === true) {
-            onAxeInProgress()
+            onAxeInProgress();
           }
         } catch (e) {}
-      })
+      });
     </script>
   </head>
   <body>

--- a/fixtures/watcher/remount.html
+++ b/fixtures/watcher/remount.html
@@ -31,6 +31,7 @@
         }
       }
 
+      let remountTimer;
       function remountButton() {
         unmountButton("temporary");
 
@@ -78,7 +79,7 @@
         remountButton();
         remountScrollableParent();
 
-        setInterval(remountButton, remountIntervalMs);
+        remountTimer = setInterval(remountButton, remountIntervalMs);
         setInterval(remountScrollableParent, remountIntervalMs);
       });
 

--- a/fixtures/watcher/remount.html
+++ b/fixtures/watcher/remount.html
@@ -31,7 +31,6 @@
         }
       }
 
-      let remountTimer;
       function remountButton() {
         unmountButton("temporary");
 
@@ -79,7 +78,7 @@
         remountButton();
         remountScrollableParent();
 
-        remountTimer = setInterval(remountButton, remountIntervalMs);
+        setInterval(remountButton, remountIntervalMs);
         setInterval(remountScrollableParent, remountIntervalMs);
       });
 


### PR DESCRIPTION
Our [cypress tests](https://github.com/dequelabs/axe-watcher/actions/runs/14359582874/job/40257599296?pr=15#step:6:373) which consume this fixture were suddenly getting errors relating to unable to append an element as its parent was no present: 

 > Cannot read properties of null (reading 'appendChild')

This patch adds a guard before we attempt to append the child element, we check to see if it exists first. I've validated this works with our Cypress tests. 

No QA Required